### PR TITLE
Fix use of NotFoundException in Helper::find_or_throw

### DIFF
--- a/helper.hpp
+++ b/helper.hpp
@@ -60,12 +60,17 @@ inline string_repr_out repr(const std::string &s) { return string_repr_out(s); }
 
 // *************************************************************************
 
+class NotFoundException : public std::exception {
+public:
+  virtual const char *what() noexcept { return nullptr; }
+};
+
 template <class KEYT, class VALT>
 inline const VALT &find_or_throw(const std::map<KEYT, VALT> &m,
                                  const KEYT &target) {
   auto i = m.find(target);
   if (i == m.end()) {
-    // throw NotFoundException();
+    throw NotFoundException();
   }
   return i->second;
 }
@@ -74,15 +79,10 @@ template <class KEYT, class VALT>
 inline VALT &find_or_throw(std::map<KEYT, VALT> &m, const KEYT &target) {
   auto i = m.find(target);
   if (i == m.end()) {
-    // throw NotFoundException();
+    throw NotFoundException();
   }
   return i->second;
 }
-
-class NotFoundException : public std::exception {
-public:
-  virtual const char *what() noexcept { return nullptr; }
-};
 
 // *************************************************************************
 


### PR DESCRIPTION
Fixes a segfault (*surprisingly*, dereferencing an invalid pointer is not a good idea).