### PR TITLE
remove trailing whitespace before comment

### DIFF
--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -206,6 +206,7 @@ void G13_Device::ReadConfigFile(const std::string &filename) {
       comment--;
       while (comment > buf && isspace(*comment))
         comment--;
+      comment++;
       *comment = 0;
     }
 

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -244,7 +244,7 @@ void G13_Device::ReadCommandsFromPipe() {
         auto command_comment = Helper::split<std::vector<std::string>>(
             cmd, "#", Helper::split::no_empties);
 
-        if (!command_comment.empty()) {
+        if (!command_comment.empty() && command_comment[0] != std::string("")) {
           while (isspace(command_comment[0].back()))
             command_comment[0].pop_back();
           if (command_comment[0] != std::string("")) {

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -243,9 +243,13 @@ void G13_Device::ReadCommandsFromPipe() {
         auto command_comment = Helper::split<std::vector<std::string>>(
             cmd, "#", Helper::split::no_empties);
 
-        if (!command_comment.empty() && command_comment[0] != std::string("")) {
-          G13_OUT("command: " << command_comment[0]);
-          Command(command_comment[0].c_str());
+        if (!command_comment.empty()) {
+          while (isspace(command_comment[0].back()))
+            command_comment[0].pop_back();
+          if (command_comment[0] != std::string("")) {
+            G13_OUT("command: " << command_comment[0]);
+            Command(command_comment[0].c_str());
+          }
         }
       }
     }


### PR DESCRIPTION
When reading commands from pipe, whitespace preceding a comment must be stripped before passing on to Command()
fixes #12