### PR TITLE
Separate piped output on press and release 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ default. Example:
 Various parts of configuring the G13 depend on assigning actions to occur based on something happening to the G13. 
 * key, possible values shown upon startup  (e.g. ***KEY_LEFTSHIFT***).
 * multiple keys,  like ***KEY_LEFTSHIFT+KEY_F1***
-* keys on release,  like ***KEY_LEFTSHIFT+KEY_F1 KEY_LEFTSHIFT+KEY_F2***
+* keys on press then release,  like ***KEY_LEFTSHIFT+KEY_F1 KEY_LEFTSHIFT+KEY_F2***
 * pipe output, by using ">" followed by text, as in ***>Hello*** - causing **Hello** (plus newline) to be written to the output pipe ( **/tmp/g13-0_out** by default )
+* pipe output on press and release, by using "|" followed by text twice, as in ***|Hello|Allo***
 * command, by using "!" followed by text, as in ***!stick_mode KEYS*** 
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Make sure you have ~~boost~~ log4cpp, libevdev and libusb-1.0 installed.
 
 ### For Archlinux
 
-Install [g13-git from AUR](https://github.com/khampf/g13)
+Install [g13-git from AUR](https://aur.archlinux.org/packages/g13-git/)
 
 ### Building from source
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ default. Example:
 Various parts of configuring the G13 depend on assigning actions to occur based on something happening to the G13. 
 * key, possible values shown upon startup  (e.g. ***KEY_LEFTSHIFT***).
 * multiple keys,  like ***KEY_LEFTSHIFT+KEY_F1***
+* keys on release,  like ***KEY_LEFTSHIFT+KEY_F1 KEY_LEFTSHIFT+KEY_F2***
 * pipe output, by using ">" followed by text, as in ***>Hello*** - causing **Hello** (plus newline) to be written to the output pipe ( **/tmp/g13-0_out** by default )
 * command, by using "!" followed by text, as in ***!stick_mode KEYS*** 
 

--- a/g13_action.cpp
+++ b/g13_action.cpp
@@ -35,9 +35,9 @@ G13_Action_Keys::G13_Action_Keys(G13_Device &keypad,
       _keysup.push_back(kval);
     }
   }
-
-  std::vector<int> _keys_local;
-  std::vector<int> _keysup_local;
+  // are these required?
+  //std::vector<int> _keys_local;
+  //std::vector<int> _keysup_local;
 }
 
 G13_Action_Keys::~G13_Action_Keys() = default;
@@ -80,14 +80,27 @@ void G13_Action_Keys::dump(std::ostream &out) const {
 }
 
 G13_Action_PipeOut::G13_Action_PipeOut(G13_Device &keypad,
-                                       const std::string &out)
-    : G13_Action(keypad), _out(out + "\n") {}
+       	                               const std::string &out,
+                                       const bool split)
+    : G13_Action(keypad) {
+  if (split) {
+    std::size_t up = out.find('|');
+    if (up!=std::string::npos && up < out.length() - 1)
+      _outup = out.substr(up+1,std::string::npos) + "\n";
+    if (up) _out = out.substr(0,up) + "\n";
+  } else _out = out + "\n";
+  // are these required?
+  //std::string _out_local;
+  //std::string _outup_local;
+}
 
 G13_Action_PipeOut::~G13_Action_PipeOut() = default;
 
 void G13_Action_PipeOut::act(G13_Device &kp, bool is_down) {
   if (is_down) {
-    kp.OutputPipeWrite(_out);
+    if(!_out.empty()) kp.OutputPipeWrite(_out);
+  } else if(!_outup.empty()) {
+    kp.OutputPipeWrite(_outup);
   }
 }
 

--- a/g13_action.cpp
+++ b/g13_action.cpp
@@ -73,9 +73,16 @@ void G13_Action_Keys::dump(std::ostream &out) const {
   out << " SEND KEYS: ";
 
   for (size_t i = 0; i < _keys.size(); i++) {
-    if (i)
-      out << " + ";
+    if (i) out << " + ";
     out << G13_Manager::Instance()->FindInputKeyName(_keys[i]);
+  }
+
+  if (!_keysup.empty()) {
+    out << ", ";
+    for (size_t i = 0; i < _keysup.size(); i++) {
+      if (i) out << " + ";
+      out << G13_Manager::Instance()->FindInputKeyName(_keysup[i]);
+    }
   }
 }
 
@@ -106,6 +113,7 @@ void G13_Action_PipeOut::act(G13_Device &kp, bool is_down) {
 
 void G13_Action_PipeOut::dump(std::ostream &o) const {
   o << "WRITE PIPE : " << Helper::repr(_out);
+  if (!_outup.empty()) o << ", " << Helper::repr(_outup);
 }
 
 G13_Action_Command::G13_Action_Command(G13_Device &keypad, std::string cmd)

--- a/g13_action.hpp
+++ b/g13_action.hpp
@@ -61,6 +61,7 @@ public:
   void dump(std::ostream &) const override;
 
   std::vector<LINUX_KEY_VALUE> _keys;
+  std::vector<LINUX_KEY_VALUE> _keysup;
 };
 
 /*!

--- a/g13_action.hpp
+++ b/g13_action.hpp
@@ -69,13 +69,14 @@ public:
  */
 class G13_Action_PipeOut : public G13_Action {
 public:
-  G13_Action_PipeOut(G13_Device &keypad, const std::string &out);
+  G13_Action_PipeOut(G13_Device &keypad, const std::string &out, const bool split);
   ~G13_Action_PipeOut() override;
 
   void act(G13_Device &, bool is_down) override;
   void dump(std::ostream &) const override;
 
   std::string _out;
+  std::string _outup;
 };
 
 /*!

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -206,6 +206,7 @@ void G13_Device::ReadConfigFile(const std::string &filename) {
       comment--;
       while (comment > buf && isspace(*comment))
         comment--;
+      comment++;
       *comment = 0;
     }
 

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -244,7 +244,7 @@ void G13_Device::ReadCommandsFromPipe() {
         auto command_comment = Helper::split<std::vector<std::string>>(
             cmd, "#", Helper::split::no_empties);
 
-        if (!command_comment.empty()) {
+        if (!command_comment.empty() && command_comment[0] != std::string("")) {
           while (isspace(command_comment[0].back()))
             command_comment[0].pop_back();
           if (command_comment[0] != std::string("")) {

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -243,9 +243,13 @@ void G13_Device::ReadCommandsFromPipe() {
         auto command_comment = Helper::split<std::vector<std::string>>(
             cmd, "#", Helper::split::no_empties);
 
-        if (!command_comment.empty() && command_comment[0] != std::string("")) {
-          G13_OUT("command: " << command_comment[0]);
-          Command(command_comment[0].c_str());
+        if (!command_comment.empty()) {
+          while (isspace(command_comment[0].back()))
+            command_comment[0].pop_back();
+          if (command_comment[0] != std::string("")) {
+            G13_OUT("command: " << command_comment[0]);
+            Command(command_comment[0].c_str());
+          }
         }
       }
     }

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -282,8 +282,8 @@ G13_ActionPtr G13_Device::MakeAction(const std::string &action) {
   if (action.empty()) {
     throw G13_CommandException("empty action string");
   }
-  if (action[0] == '>') {
-    return G13_ActionPtr(new G13_Action_PipeOut(*this, &action[1]));
+  if (action[0] == '>' || action[0] == '|') {
+    return G13_ActionPtr(new G13_Action_PipeOut(*this, &action[1], action[0] == '|'));
   } else if (action[0] == '!') {
     return G13_ActionPtr(new G13_Action_Command(*this, &action[1]));
   } else {

--- a/helper.hpp
+++ b/helper.hpp
@@ -60,12 +60,17 @@ inline string_repr_out repr(const std::string &s) { return string_repr_out(s); }
 
 // *************************************************************************
 
+class NotFoundException : public std::exception {
+public:
+  virtual const char *what() noexcept { return nullptr; }
+};
+
 template <class KEYT, class VALT>
 inline const VALT &find_or_throw(const std::map<KEYT, VALT> &m,
                                  const KEYT &target) {
   auto i = m.find(target);
   if (i == m.end()) {
-    // throw NotFoundException();
+    throw NotFoundException();
   }
   return i->second;
 }
@@ -74,15 +79,10 @@ template <class KEYT, class VALT>
 inline VALT &find_or_throw(std::map<KEYT, VALT> &m, const KEYT &target) {
   auto i = m.find(target);
   if (i == m.end()) {
-    // throw NotFoundException();
+    throw NotFoundException();
   }
   return i->second;
 }
-
-class NotFoundException : public std::exception {
-public:
-  virtual const char *what() noexcept { return nullptr; }
-};
 
 // *************************************************************************
 


### PR DESCRIPTION
Added a new command prefix '|' for binding piped output on both keydown and keyup events.
Added output to dump for release bindings