### PR TITLE
Output error if fail to open config 

### DIFF
--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -193,7 +193,7 @@ void G13_Device::ReadConfigFile(const std::string &filename) {
   std::ifstream s(filename);
 
   G13_OUT("reading configuration from " << filename);
-  if (s.fail()) G13_LOG(log4cpp::Priority::ERROR << "Error: " << strerror(errno));
+  if (s.fail()) G13_LOG(log4cpp::Priority::ERROR << strerror(errno));
   else while (s.good()) {
     // grab a line
     char buf[1024];

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -373,7 +373,7 @@ void G13_Device::InitCommands() {
   });
 
   commandAdder add_profile(
-      _command_table, "Profile",
+      _command_table, "profile",
       [this](const char *remainder) { SwitchToProfile(remainder); });
 
   commandAdder add_font(_command_table, "font", [this](const char *remainder) {

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -193,7 +193,8 @@ void G13_Device::ReadConfigFile(const std::string &filename) {
   std::ifstream s(filename);
 
   G13_OUT("reading configuration from " << filename);
-  while (s.good()) {
+  if (s.fail()) G13_LOG(log4cpp::Priority::ERROR << "Error: " << strerror(errno));
+  else while (s.good()) {
     // grab a line
     char buf[1024];
     buf[0] = 0;


### PR DESCRIPTION
Example output for nonexistent config:

1599605230 INFO  : config_fn = /etc/g13/default.bind
1599605230 INFO  : reading configuration from /etc/g13/default.bind
1599605230 ERROR  : No such file or directory