### PR TITLE
Stickzone efficiency

### DIFF
--- a/g13_action.cpp
+++ b/g13_action.cpp
@@ -49,6 +49,7 @@ void G13_Action_Keys::act(G13_Device &g13, bool is_down) {
       G13_LOG(log4cpp::Priority::DEBUG << "sending KEY DOWN " << _key);
     }
     if (!_keysup.empty()) for (int i = _keys.size() - 1; i >= 0; i--) {
+      g13.SendEvent(EV_SYN, SYN_REPORT, 0);
       g13.SendEvent(EV_KEY, _keys[i], !is_down);
       G13_LOG(log4cpp::Priority::DEBUG << "sending KEY UP " << _keys[i]);
     }
@@ -61,6 +62,7 @@ void G13_Action_Keys::act(G13_Device &g13, bool is_down) {
         g13.SendEvent(EV_KEY, _key, !is_down);
         G13_LOG(log4cpp::Priority::DEBUG << "sending KEY DOWN " << _key);
       }
+      g13.SendEvent(EV_SYN, SYN_REPORT, 0);
       for (int i = _keysup.size() - 1; i >= 0; i--) {
         g13.SendEvent(EV_KEY, _keysup[i], is_down);
         G13_LOG(log4cpp::Priority::DEBUG << "sending KEY UP " << _keysup[i]);

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -193,7 +193,7 @@ void G13_Device::ReadConfigFile(const std::string &filename) {
   std::ifstream s(filename);
 
   G13_OUT("reading configuration from " << filename);
-  if (s.fail()) G13_LOG(log4cpp::Priority::ERROR << strerror(errno));
+  if (s.fail()) G13_LOG(log4cpp::Priority::ERROR << "Error: " << strerror(errno));
   else while (s.good()) {
     // grab a line
     char buf[1024];
@@ -435,8 +435,13 @@ void G13_Device::InitCommands() {
             if (sscanf(remainder, "%lf %lf %lf %lf", &x1, &y1, &x2, &y2) != 4) {
               throw G13_CommandException("bad bounds format");
             }
-            zone->set_bounds(G13_ZoneBounds(x1, y1, x2, y2));
-
+            // TODO: Add center offset and bounds (or update zone)
+            zone->set_bounds(G13_ZoneBounds(
+              (unsigned char)(x1 * UCHAR_MAX),
+              (unsigned char)(y1 * UCHAR_MAX),
+              (unsigned char)(x2 * UCHAR_MAX),
+              (unsigned char)(y2 * UCHAR_MAX)
+            ));
           } else if (operation == "del") {
             m_stick.RemoveZone(*zone);
           } else {

--- a/g13_device.cpp
+++ b/g13_device.cpp
@@ -193,7 +193,7 @@ void G13_Device::ReadConfigFile(const std::string &filename) {
   std::ifstream s(filename);
 
   G13_OUT("reading configuration from " << filename);
-  if (s.fail()) G13_LOG(log4cpp::Priority::ERROR << "Error: " << strerror(errno));
+  if (s.fail()) G13_LOG(log4cpp::Priority::ERROR << strerror(errno));
   else while (s.good()) {
     // grab a line
     char buf[1024];

--- a/g13_manager.cpp
+++ b/g13_manager.cpp
@@ -258,7 +258,7 @@ int G13_Manager::Run() {
         running = false;
       }
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   } while (running);
 
   Cleanup();

--- a/g13_manager.cpp
+++ b/g13_manager.cpp
@@ -10,6 +10,8 @@
 #include <libevdev-1.0/libevdev/libevdev.h>
 #include <log4cpp/OstreamAppender.hh>
 #include <memory>
+#include <chrono>
+#include <thread>
 
 namespace G13 {
 
@@ -256,6 +258,7 @@ int G13_Manager::Run() {
         running = false;
       }
     }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
   } while (running);
 
   Cleanup();

--- a/g13_stick.cpp
+++ b/g13_stick.cpp
@@ -113,6 +113,11 @@ void G13_Stick::ParseJoystick(const unsigned char *buf) {
 
   // update targets if we're in calibration mode
   switch (m_stick_mode) {
+  case STICK_ABSOLUTE:
+    break;
+  case STICK_KEYS:
+    break;
+
   case STICK_CALCENTER:
     m_center_pos = m_current_pos;
     return;
@@ -124,13 +129,10 @@ void G13_Stick::ParseJoystick(const unsigned char *buf) {
   case STICK_CALBOUNDS:
     m_bounds.expand(m_current_pos);
     return;
-
-  case STICK_ABSOLUTE:
-    break;
-  case STICK_KEYS:
-    break;
   }
-
+/* TODO: Transform zone so we're not constantly transforming position
+ *  Is this even necessary? Zones could just be tweaked manually and
+ *  north is currently unused. Four-point zones would be more powerful
   // determine our normalized position
   double dx; // = 0.5
   if (m_current_pos.x <= m_center_pos.x) {
@@ -153,13 +155,14 @@ void G13_Stick::ParseJoystick(const unsigned char *buf) {
 
   G13_DBG("x=" << m_current_pos.x << " y=" << m_current_pos.y << " dx=" << dx
                << " dy=" << dy);
-  G13_ZoneCoord jpos(dx, dy);
+  G13_ZoneCoord jpos(dx, dy);*/
   if (m_stick_mode == STICK_ABSOLUTE) {
     _keypad.SendEvent(EV_ABS, ABS_X, m_current_pos.x);
     _keypad.SendEvent(EV_ABS, ABS_Y, m_current_pos.y);
 
   } else if (m_stick_mode == STICK_KEYS) {
     // BOOST_FOREACH (G13_StickZone& zone, m_zones) { zone.test(jpos); }
+    G13_ZoneCoord jpos(m_current_pos.x, m_current_pos.y);
     for (auto &zone : m_zones) {
       zone.test(jpos);
     }

--- a/g13_stick.cpp
+++ b/g13_stick.cpp
@@ -94,16 +94,9 @@ void G13_StickZone::dump(std::ostream &out) const {
 void G13_StickZone::test(const G13_ZoneCoord &loc) {
   if (!_action)
     return;
-  bool prior_active = _active;
-  _active = _bounds.contains(loc);
-  if (!_active) {
-    if (prior_active) {
-      // cout << "exit stick zone " << m_name << std::endl;
-      _action->act(false);
-    }
-  } else {
-    // cout << "in stick zone " << m_name << std::endl;
-    _action->act(true);
+  if (_active != _bounds.contains(loc)) {
+    _active = !_active;
+    _action->act(_active);
   }
 }
 

--- a/g13_stick.cpp
+++ b/g13_stick.cpp
@@ -162,9 +162,8 @@ void G13_Stick::ParseJoystick(const unsigned char *buf) {
 
   } else if (m_stick_mode == STICK_KEYS) {
     // BOOST_FOREACH (G13_StickZone& zone, m_zones) { zone.test(jpos); }
-    G13_ZoneCoord jpos(m_current_pos.x, m_current_pos.y);
     for (auto &zone : m_zones) {
-      zone.test(jpos);
+      zone.test(G13_ZoneCoord(m_current_pos.x, m_current_pos.y));
     }
     return;
 

--- a/g13_stick.hpp
+++ b/g13_stick.hpp
@@ -13,8 +13,8 @@ class G13_Device;
 
 typedef Helper::Coord<int> G13_StickCoord;
 typedef Helper::Bounds<int> G13_StickBounds;
-typedef Helper::Coord<double> G13_ZoneCoord;
-typedef Helper::Bounds<double> G13_ZoneBounds;
+typedef Helper::Coord<unsigned char> G13_ZoneCoord;
+typedef Helper::Bounds<unsigned char> G13_ZoneBounds;
 
 // *************************************************************************
 


### PR DESCRIPTION
Improves stickzone efficiency and reliability by limiting maximum sampling frequency and performing coordinate transformation of zone in advance. Does not take into consideration centre or bounds calibration which add little value. Is this worth re-implementing?
fixes #21